### PR TITLE
Ben Manes Versions plugin: Version 0.28.0 is not available. Version 0.46.0 seems to work. 

### DIFF
--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,5 +1,5 @@
 object Versions {
     const val kotlin = "1.3.72"
-    const val versions_plugin = "0.28.0"
+    const val versions_plugin = "0.46.0"
     const val jupiter = "5.6.2"
 }


### PR DESCRIPTION
When you use JDK 11 (A JDK <14 is required for Gradle 6.4)